### PR TITLE
Update persistent storage link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,7 +29,7 @@ nav:
   - Storage:
       - Your code: https://github.com/CU-ESIIL/defining-tipping-points-and-transformation-innovation-summit-2025__1/tree/main/code
       - Your documentation: https://github.com/CU-ESIIL/defining-tipping-points-and-transformation-innovation-summit-2025__1/tree/main/documentation
-      - Your persistent storage: https://de.cyverse.org/data/ds/iplant/home/shared/esiil/Innovation_summit/Group_1
+      - Your persistent storage: https://de.cyverse.org/data/ds/iplant/home/shared/esiil/Innovation_summit/Group_1?type=folder&resourceId=1993057e-8e90-11f0-b0fa-90e2ba675364
   - Orientation:
       - Summit slides: orientation/slides.md
       - ESIIL training: orientation/esiil_training.md


### PR DESCRIPTION
## Summary
- update the Storage navigation link for persistent storage to the latest CyVerse folder URL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d15eccd53c8325a1608b89c45bc1f1